### PR TITLE
Fixing Lava Imp's Drops

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -95,7 +95,7 @@
 	throw_message = "does nothing to the tough hide of the"
 	pre_attack_icon = "goliath2"
 	crusher_loot = /obj/item/crusher_trophy/goliath_tentacle
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/stack/sheet/bone = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/goliath = 2, /obj/item/stack/sheet/bone = 3)
 	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/goliath_hide = 1)
 	loot = list()
 	stat_attack = UNCONSCIOUS

--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/imp.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/imp.dm
@@ -34,7 +34,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/impskull
 	loot = list()
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2, /obj/item/stack/sheet/bone = 3, /obj/item/stack/sheet/sinew = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2, /obj/item/stack/sheet/bone = 4)
 	robust_searching = FALSE
 	death_sound = 'modular_skyrat/sound/misc/impdies.wav'
 	glorymessageshand = list("grabs the imp's eyes and rips them out, shoving the bloody imp aside!", "grabs and crushes the imp's skull apart with their bare hands!", "rips the imp's head clean off with their bare hands!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lava Imp's dont drop Sinews anymore. Small buff to Imp Bone Drops (4 Bones instead of 3). Small buff to Goliath Bone Drops too (3 Bones instead of 2)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More utility for Lava Imps. No more Watcher 2.0.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

tweak: Imps dont drop Sinews anymore. Now they drop 4 bones instead of 3.
tweak: Goliath now drops 3 Bones instead of only 2.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
